### PR TITLE
chore: demo-rules-loading-fallback'

### DIFF
--- a/examples/demo-react/src/rules/ab-test.json
+++ b/examples/demo-react/src/rules/ab-test.json
@@ -1,0 +1,20 @@
+{
+  "meta": { "version": "1.0.0", "generatedAt": "2025-08-12T00:00:00.000Z" },
+  "rules": [
+    {
+      "if": { "lang": ["es", "es-es"] },
+      "target": { "web": "https://es.example.com" },
+      "reason": "Spanish locale → ES site"
+    },
+    {
+      "if": { "rollout": { "lte": 30 } },
+      "target": { "web": "https://example.com/landing-new" },
+      "reason": "A/B: new landing for first 30%"
+    }
+  ],
+
+  "default": {
+    "target": { "web": "https://example.com/landing-control" },
+    "reason": "A/B control (70%)"
+  }
+}

--- a/examples/demo-react/src/rules/campaign.json
+++ b/examples/demo-react/src/rules/campaign.json
@@ -1,0 +1,39 @@
+{
+  "meta": { "version": "1.0.0", "generatedAt": "2025-08-12T00:00:00.000Z" },
+
+  "rules": [
+    {
+      "if": {
+        "dateRange": {
+          "from": "2025-08-01T00:00:00.000Z",
+          "to":   "2025-08-31T23:59:59.999Z"
+        }
+      },
+      "target": { "web": "https://example.com/campaign/summer-2025" },
+      "reason": "Campaign window → summer 2025"
+    },
+    {
+      "if": { "os": ["iOS"] },
+      "target": {
+        "ios": "myapp://home",
+        "web": "https://example.com/ios",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on iOS outside campaign window"
+    },
+    {
+      "if": { "os": ["Android"] },
+      "target": {
+        "android": "myapp://home",
+        "web": "https://example.com/android",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on Android outside campaign window"
+    }
+  ],
+
+  "default": {
+    "target": { "web": "https://example.com" },
+    "reason": "Desktop or unmatched → default site"
+  }
+}

--- a/examples/demo-react/src/rules/demo.json
+++ b/examples/demo-react/src/rules/demo.json
@@ -1,0 +1,52 @@
+{
+  "meta": { "version": "1.1.0", "generatedAt": "2025-08-12T00:00:00.000Z" },
+  "rules": [
+    {
+      "if": { "os": ["iOS"] },
+      "target": {
+        "ios": "myapp://home",
+        "web": "https://example.com/ios",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on iOS"
+    },
+    {
+      "if": { "os": ["Android"] },
+      "target": {
+        "android": "myapp://home",
+        "web": "https://example.com/android",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on Android"
+    },
+    {
+      "if": { "lang": ["es", "es-es"] },
+      "target": {
+        "web": "https://es.example.com"
+      },
+      "reason": "Spanish locale → ES site"
+    },
+    {
+      "if": {
+        "dateRange": { "from": "2025-08-01T00:00:00.000Z", "to": "2025-08-31T23:59:59.999Z" }
+      },
+      "target": {
+        "web": "https://example.com/campaign/summer-2025"
+      },
+      "reason": "Campaign window → Summer 2025 landing"
+    },
+    {
+      "if": { "rollout": { "lte": 30 } },
+      "target": {
+        "web": "https://example.com/landing-new"
+      },
+      "reason": "30% rollout → new landing"
+    }
+  ],
+  "default": {
+    "target": {
+      "web": "https://example.com"
+    },
+    "reason": "Default route"
+  }
+}

--- a/examples/demo-react/src/rules/lang-matrix.json
+++ b/examples/demo-react/src/rules/lang-matrix.json
@@ -1,0 +1,29 @@
+{
+  "meta": { "version": "1.0.0", "generatedAt": "2025-08-12T00:00:00.000Z" },
+  "rules": [
+    {
+      "if": { "lang": ["es", "es-es"] },
+      "target": { "web": "https://es.example.com" },
+      "reason": "Spanish → ES site"
+    },
+    {
+      "if": { "lang": ["en", "en-us", "en-gb"] },
+      "target": { "web": "https://en.example.com" },
+      "reason": "English → EN site"
+    },
+    {
+      "if": { "lang": ["fr", "fr-fr"] },
+      "target": { "web": "https://fr.example.com" },
+      "reason": "French → FR site"
+    },
+    {
+      "if": { "lang": ["de", "de-de"] },
+      "target": { "web": "https://de.example.com" },
+      "reason": "German → DE site"
+    }
+  ],
+  "default": {
+    "target": { "web": "https://example.com" },
+    "reason": "Default route"
+  }
+}

--- a/examples/demo-react/src/rules/mobile-priority.json
+++ b/examples/demo-react/src/rules/mobile-priority.json
@@ -1,0 +1,27 @@
+{
+  "meta": { "version": "1.0.0", "generatedAt": "2025-08-12T00:00:00.000Z" },
+  "rules": [
+    {
+      "if": { "os": ["iOS"] },
+      "target": {
+        "ios": "myapp://home",
+        "web": "https://example.com/ios",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on iOS"
+    },
+    {
+      "if": { "os": ["Android"] },
+      "target": {
+        "android": "myapp://home",
+        "web": "https://example.com/android",
+        "fallback": "https://example.com/fallback"
+      },
+      "reason": "Prefer app on Android"
+    }
+  ],
+  "default": {
+    "target": { "web": "https://example.com" },
+    "reason": "Desktop or unmatched → default site"
+  }
+}


### PR DESCRIPTION
## What does this change?
- **Fix demo 404s** when loading `/rules/*.json` on Vercel.
- Build the URL with `import.meta.env.BASE_URL` so it works in dev/prod/subpaths.
- Add **fallback**: if fetching `/rules/<preset>.json` fails (e.g., 404), load a **bundled** JSON from `src/rules/<preset>.json` (no network needed).
- Keep presets and minimal console logging for easier debugging.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Chore / Refactor
- [ ] Performance
- [ ] Test

## Related issues
Demo failing with 404 for `/rules/campaign.json` (and other presets) on Vercel.

## How was this tested?
- Local:
  - `pnpm -C examples/demo-react dev` → presets load without errors.
  - `pnpm -C examples/demo-react build && pnpm -C examples/demo-react preview` → no 404s; if network fetch is forced to fail, fallback kicks in.
- Vercel (Preview): confirm no 404s and presets work.
- No impact on `@smartqr/core` or `@smartqr/react`.

**Commands**
```bash
pnpm -C examples/demo-react dev
pnpm -C examples/demo-react build && pnpm -C examples/demo-react preview
